### PR TITLE
feat: use categorized conventional-commit release notes

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -193,10 +193,23 @@ jobs:
         failStepIfUnsuccessful: true
         appSlugFilter: github-actions
 
+
+    - name: Generate release notes
+      id: release_notes
+      if: steps.get_target_release.outputs.create_release == 'true'
+      uses: SAP/cs-actions/generate-release-notes-action@main
+      with:
+        personal-token: ${{ secrets.WORKFLOW_USER_GH_TOKEN }}
+        new-tag: ${{ steps.get_target_release.outputs.tag }}
+        previous-tag: ${{ steps.get_current_release.outputs.tag }}
+        target-ref: ${{ steps.get_target_commit.outputs.sha }}
+
     - name: Create Release
       if: steps.get_target_release.outputs.create_release == 'true'
       env:
         GH_TOKEN: ${{ secrets.WORKFLOW_USER_GH_TOKEN }}
       run: |
         gh release create ${{ steps.get_target_release.outputs.tag }} \
-          --target "${{ steps.get_target_commit.outputs.sha }}"
+          --target "${{ steps.get_target_commit.outputs.sha }}" \
+          --title "${{ steps.get_target_release.outputs.tag }}" \
+          --notes "${{ steps.release_notes.outputs.release-notes }}"


### PR DESCRIPTION
## Summary

- Replaces bare `gh release create` (no title, no notes) with [`SAP/cs-actions/generate-release-notes-action`](https://github.com/SAP/cs-actions/tree/main/generate-release-notes-action)
- Future releases will have categorized notes based on conventional commit prefixes:
  - **Breaking Changes** (`feat!:`, `fix!:`, etc.)
  - **New Features** (`feat:`)
  - **Bug Fixes** (`fix:`)
  - **Improvements** (`chore:`, `refactor:`, `ci:`, `build:`, `perf:`, etc.)
  - **Documentation** (`docs:`)
  - **Other Changes** (non-conventional commits)

### Reference implementation

| Step | Link |
|------|------|
| Reusable action | [SAP/cs-actions#4](https://github.com/SAP/cs-actions/pull/4) |
| Workflow update | [SAP/clustersecret-operator#133](https://github.com/SAP/clustersecret-operator/pull/133) |
| End-to-end proof | [v0.3.74](https://github.com/SAP/clustersecret-operator/releases/tag/v0.3.74) |

Part of [cs-devops/cs-devops#1417](https://github.tools.sap/cs-devops/cs-devops/issues/1417).
